### PR TITLE
Fetching Thumbnails for Inline Queries from Bing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Desktop.ini
 #Tokens
 mensabot.conf
 
+# cache
+storage/
+

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ repositories {
 }
 
 group 'com.github.silvanheller.mensabot'
-version '1.1.0'
+version '1.2.0'
 
 def mainClassName = 'com.github.silvanheller.mensabot.main.Main'
 

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,8 @@ jar {
         configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) }
     }
     archiveBaseName.set("mensa-bot")
+
+    exclude("META-INF/*.RSA", "META-INF/*.DSA", "META-INF/*.SF")
 }
 
 rootProject.tasks.named("jar") {

--- a/build.gradle
+++ b/build.gradle
@@ -22,13 +22,20 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.+'
     implementation 'org.apache.logging.log4j:log4j-core:2.+'
 
+    // JSON
+    implementation group: 'com.google.code.gson', name: 'gson', version: '2.8.9'
+
+    // API Requests
+    implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.9.3'
+    implementation group: 'com.microsoft.bing', name: 'bing-imagesearch', version: '1.0.0'
+
     ////// TELEGRAM
     implementation group: 'org.telegram', name: 'telegrambots', version: '5.+'
 
-    //CONFIG
+    // CONFIG
     implementation group: 'com.typesafe', name: 'config', version: '1.+'
 
-    //SCRAPING
+    // SCRAPING
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.+'
 }
 

--- a/src/main/java/com/github/silvanheller/mensabot/config/BotConfig.java
+++ b/src/main/java/com/github/silvanheller/mensabot/config/BotConfig.java
@@ -3,11 +3,14 @@ package com.github.silvanheller.mensabot.config;
 import com.typesafe.config.ConfigFactory;
 
 /**
- * Config model, which only includes two things: bot tokken and username
+ * Config model, which only includes two things: bot token and username
  */
 public class BotConfig {
 
     public static final String SECRET_TOKEN = ConfigFactory.load("mensabot").getString("mensa-bot.token");
     public static final String BOT_USERNAME = ConfigFactory.load("mensabot").getString("mensa-bot.botname");
+    public static final String BING_TOKEN = ConfigFactory.load("mensabot").getString("bing.token");
+    public static final String IMAGE_FINDER = ConfigFactory.load("mensabot").getString("mensa-bot.imagefinder");
+    public static final Boolean THUMBNAILS_ENABLED = ConfigFactory.load("mensabot").getBoolean("thumbnails.enabled");
 
 }

--- a/src/main/java/com/github/silvanheller/mensabot/core/MensaBot.java
+++ b/src/main/java/com/github/silvanheller/mensabot/core/MensaBot.java
@@ -34,15 +34,17 @@ public class MensaBot extends TelegramLongPollingBot {
     }
 
     private void initCache() {
-        LOGGER.debug("initializing cache");
-        try {
-            var menu = MainMensaScraper.getMenu();
-            menu.getItems().forEach(food -> {
-                LOGGER.debug("initializing cache for {}", food.getTitle());
-                finder.getThumbURLForFood(food.getTitle());
-            });
-        } catch (IOException e) {
-            e.printStackTrace();
+        if (BotConfig.THUMBNAILS_ENABLED) {
+            LOGGER.debug("initializing cache");
+            try {
+                var menu = MainMensaScraper.getMenu();
+                menu.getItems().forEach(food -> {
+                    LOGGER.debug("initializing cache for {}", food.getTitle());
+                    finder.getThumbURLForFood(food.getTitle());
+                });
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
         }
     }
 

--- a/src/main/java/com/github/silvanheller/mensabot/main/BingSearch.java
+++ b/src/main/java/com/github/silvanheller/mensabot/main/BingSearch.java
@@ -1,0 +1,85 @@
+package com.github.silvanheller.mensabot.main;
+
+import com.microsoft.bing.imagesearch.models.ImageObject;
+import com.microsoft.bing.imagesearch.models.Images;
+import com.microsoft.bing.imagesearch.implementation.ImageSearchClientImpl;
+import com.microsoft.rest.credentials.ServiceClientCredentials;
+import okhttp3.*;
+import okhttp3.OkHttpClient.Builder;
+import java.io.IOException;
+import java.util.List;
+import java.util.ArrayList;
+import com.github.silvanheller.mensabot.config.BotConfig;
+
+public class BingSearch {
+
+    /**
+     * Main function which runs the actual sample.
+     *
+     * @param client instance of the Bing News Search API client
+     * @param searchTerm a term to use in the image search request
+     * @return true if sample runs successfully
+     */
+    public static void runSample(ImageSearchClientImpl client, String searchTerm) {
+        try {
+
+            //=============================================================
+            // This will search images for "canadian rockies" then print the first image result,
+
+            System.out.println(String.format("Search images for query %s", searchTerm));
+
+            Images imageResults = client.images().search(searchTerm);
+
+            if (imageResults != null && imageResults.value().size() > 0) {
+                // Image results
+                ImageObject firstImageResult = imageResults.value().get(0);
+
+                System.out.println(String.format("Image result count: %d", imageResults.value().size()));
+                System.out.println(String.format("First image insights token: %s", firstImageResult.imageInsightsToken()));
+                System.out.println(String.format("First image thumbnail url: %s", firstImageResult.thumbnailUrl()));
+                System.out.println(String.format("First image content url: %s", firstImageResult.contentUrl()));
+                System.out.print(imageResults.value().size()+ " results");
+            }
+            else {
+                System.out.println("Couldn't find any image results!");
+            }
+        }
+        catch (Exception f) {
+            System.out.println(f.getMessage());
+            f.printStackTrace();
+        }
+    }
+
+    /**
+     * Main entry point.
+     *
+     * @param args the parameters
+     */
+    public static void main(String[] args) {
+        try {
+            // Authenticate
+            // Set the BING_SEARCH_V7_SUBSCRIPTION_KEY environment variable,
+            // then reopen your command prompt or IDE for changes to take effect.
+            final String subscriptionKey = BotConfig.BING_TOKEN;
+            // Add your Bing Search V7 endpoint to your environment variables.
+            String endpoint = "https://api.bing.microsoft.com/v7.0";
+
+            ServiceClientCredentials credentials = builder -> builder.addNetworkInterceptor(
+                    chain -> {
+                        Request request = null;
+                        Request original = chain.request();
+                        Request.Builder requestBuilder = original.newBuilder();
+                        requestBuilder.addHeader("Ocp-Apim-Subscription-Key", subscriptionKey);
+                        request = requestBuilder.build();
+                        return chain.proceed(request);
+                    }
+            );
+            ImageSearchClientImpl client = new ImageSearchClientImpl(endpoint,credentials);
+            String searchTerm = "Wienerli";
+            runSample(client, searchTerm);
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/silvanheller/mensabot/main/Main.java
+++ b/src/main/java/com/github/silvanheller/mensabot/main/Main.java
@@ -1,6 +1,9 @@
 package com.github.silvanheller.mensabot.main;
 
+import com.github.silvanheller.mensabot.config.BotConfig;
 import com.github.silvanheller.mensabot.core.MensaBot;
+import com.github.silvanheller.mensabot.visuals.BingImageFinder;
+import com.github.silvanheller.mensabot.visuals.ImageFinder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.telegram.telegrambots.meta.TelegramBotsApi;
@@ -19,9 +22,16 @@ public class Main {
 
     public static void main(String[] args) throws TelegramApiException {
         var telegramBotsApi = new TelegramBotsApi(DefaultBotSession.class);
-
+        ImageFinder finder = null;
+        switch (BotConfig.IMAGE_FINDER) {
+            case "bing":
+                finder = new BingImageFinder();
+                break;
+            case "google":
+                throw new UnsupportedOperationException();
+        }
         try {
-            telegramBotsApi.registerBot(new MensaBot());
+            telegramBotsApi.registerBot(new MensaBot(finder));
             LOGGER.info("Successfully registered Bot!");
         } catch (TelegramApiException e) {
             LOGGER.error(e);

--- a/src/main/java/com/github/silvanheller/mensabot/scraper/Food.java
+++ b/src/main/java/com/github/silvanheller/mensabot/scraper/Food.java
@@ -66,7 +66,7 @@ public class Food {
      */
     public String getDescriptionString() {
         var builder = new StringBuilder();
-        builder.append(description).append("\n");
+        builder.append(description).append(" \n");
         if (!studentPrice.equals(PRICE_NOT_FOUND)) {
             builder.append("Preis: ").append(studentPrice).append("\n");
         }
@@ -82,7 +82,6 @@ public class Food {
         msg.setParseMode("Markdown");
         return msg;
     }
-
 
     public String markdownString() {
         var builder = new StringBuilder();

--- a/src/main/java/com/github/silvanheller/mensabot/scraper/Menu.java
+++ b/src/main/java/com/github/silvanheller/mensabot/scraper/Menu.java
@@ -1,6 +1,8 @@
 package com.github.silvanheller.mensabot.scraper;
 
 import com.github.silvanheller.mensabot.util.GermanWeekdayConv;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.inputmessagecontent.InputMessageContent;
+import org.telegram.telegrambots.meta.api.objects.inlinequery.inputmessagecontent.InputTextMessageContent;
 
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -97,6 +99,16 @@ public class Menu {
             builder.append("\n");
         }
         return builder.toString();
+    }
+
+    /**
+     * See https://core.telegram.org/bots/api#inputmessagecontent for Documentation
+     */
+    public InputMessageContent getInputMessageMarkdownContent() {
+        var msg = new InputTextMessageContent();
+        msg.setMessageText(markdownString());
+        msg.setParseMode("Markdown");
+        return msg;
     }
 
     private String getTitle() {

--- a/src/main/java/com/github/silvanheller/mensabot/visuals/BingImageFinder.java
+++ b/src/main/java/com/github/silvanheller/mensabot/visuals/BingImageFinder.java
@@ -1,0 +1,116 @@
+package com.github.silvanheller.mensabot.visuals;
+
+import com.github.silvanheller.mensabot.config.BotConfig;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.microsoft.bing.imagesearch.implementation.ImageSearchClientImpl;
+import com.microsoft.bing.imagesearch.models.ImageObject;
+import com.microsoft.rest.credentials.ServiceClientCredentials;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.*;
+import java.lang.reflect.Type;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class BingImageFinder extends ImageFinder {
+
+    private static final Type LIST_TYPE = new TypeToken<List<ImageObject>>() {
+    }.getType();
+    private static final Logger LOGGER = LogManager.getLogger();
+    private ImageSearchClientImpl imgSearchClient;
+    private boolean init = false;
+    private static final Gson gson = new Gson();
+    private static final OkHttpClient okHttpClient = new OkHttpClient();
+
+
+    public BingImageFinder() {
+        try {
+            // Authenticate
+            // Set the BING_SEARCH_V7_SUBSCRIPTION_KEY environment variable,
+            // then reopen your command prompt or IDE for changes to take effect.
+            final String subscriptionKey = BotConfig.BING_TOKEN;
+            // Add your Bing Search V7 endpoint to your environment variables.
+            String endpoint = "https://api.bing.microsoft.com/v7.0";
+
+            ServiceClientCredentials credentials = builder -> builder.addNetworkInterceptor(
+                    chain -> {
+                        Request request = null;
+                        Request original = chain.request();
+                        Request.Builder requestBuilder = original.newBuilder();
+                        requestBuilder.addHeader("Ocp-Apim-Subscription-Key", subscriptionKey);
+                        request = requestBuilder.build();
+                        return chain.proceed(request);
+                    }
+            );
+            imgSearchClient = new ImageSearchClientImpl(endpoint, credentials);
+            init = true;
+
+        } catch (Exception e) {
+            LOGGER.error("Initialization of Bing Image Finder failed");
+        }
+    }
+
+    @Override
+    protected String fetchThumbURLForFood(String food) {
+        if (!init) {
+            // no initialization = no queries
+            return null;
+        }
+        List<ImageObject> images = null;
+        var storage = Paths.get("storage", food, "response.json");
+        if (storage.toFile().exists()) {
+            LOGGER.debug("cache-hit");
+            JsonReader reader = null;
+            try {
+                reader = new JsonReader(new FileReader(storage.toFile()));
+                images = gson.fromJson(reader, LIST_TYPE);
+            } catch (FileNotFoundException e) {
+                e.printStackTrace();
+                return null;
+            }
+        } else {
+            var results = imgSearchClient.images().search(food);
+            if (results == null) {
+                LOGGER.warn("null as a result from bing API");
+                return null;
+            }
+            images = results.value();
+        }
+        if (images.size() == 0) {
+            LOGGER.warn("no results for food: " + food);
+            return null;
+        }
+        List<ImageObject> finalImages = images;
+        new Thread(() -> storeResults(finalImages, food)).start();
+        return images.get(0).thumbnailUrl();
+    }
+
+    private void storeResults(List<ImageObject> results, String query) {
+        try {
+            var storage = Paths.get("storage", query);
+            storage.toFile().mkdirs();
+            var jsonPath = storage.resolve("response.json");
+            var fw = new FileWriter(jsonPath.toFile());
+            gson.toJson(results, fw);
+            fw.flush();
+            fw.close();
+            for (ImageObject img : results) {
+                var imagePath = storage.resolve(img.imageId() + ".jpg");
+                var request = new Request.Builder().url(img.thumbnailUrl()).build();
+                var response = okHttpClient.newCall(request).execute();
+                InputStream inputStream = response.body().byteStream();
+                BufferedImage image = ImageIO.read(inputStream);
+                ImageIO.write(image, "jpg", imagePath.toFile());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/com/github/silvanheller/mensabot/visuals/ImageFinder.java
+++ b/src/main/java/com/github/silvanheller/mensabot/visuals/ImageFinder.java
@@ -1,0 +1,28 @@
+package com.github.silvanheller.mensabot.visuals;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class ImageFinder {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+    private Map<String, String> urlCache = new HashMap<>();
+
+    public String getThumbURLForFood(String food) {
+        if (urlCache.containsKey(food)) {
+            return urlCache.get(food);
+        }
+        String url = fetchThumbURLForFood(food);
+        if (url == null || url.isEmpty()) {
+            LOGGER.warn("no url for food {}", food);
+            return null;
+        }
+        urlCache.put(food, url);
+        return url;
+    }
+
+    protected abstract String fetchThumbURLForFood(String food);
+}

--- a/src/main/resources/config.template
+++ b/src/main/resources/config.template
@@ -2,4 +2,13 @@
 mensa-bot {
     token="DO_NOT_UPLOAD_YOUR_SECRET_TOKEN"
     botname="UnibasMensaBot"
+    imagefinder="bing"
+}
+
+bing {
+    token="DO_NOT_UPLOAD"
+}
+
+thumbnails {
+    enabled="false"
 }


### PR DESCRIPTION
If the corresponding config flag is set, an image query is sent to the Bing API and the first image is displayed as thumbnail. Caching functionality is enabled and stores already executed queries.